### PR TITLE
Add cloudfront distribution in front of s3 bucket

### DIFF
--- a/components/website-cms/cloudfront.tf
+++ b/components/website-cms/cloudfront.tf
@@ -41,6 +41,12 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     compress               = true
   }
 
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
   viewer_certificate {
     cloudfront_default_certificate = true
     minimum_protocol_version = "TLSv1.2_2019"


### PR DESCRIPTION
I haven't made the s3 bucket private yet because live images on the site are using them. Once i've updated the site to point to the CF distribution, I'll make that final change.