### PR TITLE
fix: avoid reserved names and oidc fix

### DIFF
--- a/components/website-cms/oidc.tf
+++ b/components/website-cms/oidc.tf
@@ -23,9 +23,13 @@ module "oidc" {
   ]
 }
 
+data "aws_iam_policy" "readonly" {
+  name = "ReadOnlyAccess"
+}
+
 resource "aws_iam_role_policy_attachment" "readonly" {
   role       = local.plan_name
-  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+  policy_arn = data.aws_iam_policy.readonly.arn
 }
 
 ## Gives the plan role access to all secrets in the repo this is needed since ReadOnly doesn't provide that access
@@ -41,7 +45,11 @@ module "attach_tf_plan_policy" {
   billing_tag_value = var.product_name
 }
 
+data "aws_iam_policy" "admin" {
+  name = "AdministratorAccess"
+}
+
 resource "aws_iam_role_policy_attachment" "admin" {
   role       = local.admin_name
-  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+  policy_arn = data.aws_iam_policy.admin.arn
 }

--- a/components/website-cms/ssm.tf
+++ b/components/website-cms/ssm.tf
@@ -1,23 +1,23 @@
 resource "aws_ssm_parameter" "db_password" {
-  name  = "db_password"
+  name  = "/website/db_password"
   type  = "SecureString"
   value = var.rds_cluster_password
 }
 
 resource "aws_ssm_parameter" "github_token" {
-  name  = "github_token"
+  name  = "/website/github_token"
   type  = "SecureString"
   value = var.github_token
 }
 
 resource "aws_ssm_parameter" "aws_access_key_id" {
-  name  = "aws_access_key_id"
+  name  = "/website/aws_access_key_id"
   type  = "SecureString"
   value = var.strapi_aws_access_key_id
 }
 
 resource "aws_ssm_parameter" "aws_secret_access_key" {
-  name  = "aws_access_key_id"
+  name  = "/website/aws_access_key_id"
   type  = "SecureString"
   value = var.strapi_aws_secret_access_key
 }


### PR DESCRIPTION
SSM parameters cannot start with aws. This also fixes the oidc roles dependency chain since terraform tried to apply the policies before the role was created.