### PR TITLE
fix: remove envs that reside in secrets

### DIFF
--- a/components/website-cms/task-definitions/cms_app.json.tpl
+++ b/components/website-cms/task-definitions/cms_app.json.tpl
@@ -21,14 +21,6 @@
         "value": "${bucket_name}"
       },
       {
-        "name": "AWS_ACCESS_KEY_ID",
-        "value": "${aws_access_key_id}"
-      },
-      {
-        "name": "AWS_SECRET_ACCESS_KEY",
-        "value": "${aws_secret_access_key}"
-      },
-      {
         "name": "DATABASE_USERNAME",
         "value": "${db_user}"
       }


### PR DESCRIPTION
These 2 env's were accidently left in the `env` block when they were migrated into ssm parameters and referenced in the `secrets` block