### PR TITLE
chore: remove AWS access ID and secret

### DIFF
--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -19,8 +19,6 @@ env:
   TERRAGRUNT_VERSION: 0.31.1
   TF_VAR_rds_cluster_password: ${{ secrets.RDS_CLUSTER_PASSWORD }}
   TF_VAR_asset_bucket_name: ${{ secrets.ASSET_BUCKET_NAME }}
-  TF_VAR_strapi_aws_access_key_id: ${{ secrets.STRAPI_AWS_ACCESS_KEY_ID }}
-  TF_VAR_strapi_aws_secret_access_key: ${{ secrets.STRAPI_AWS_SECRET_ACCESS_KEY }}
   TF_VAR_strapi_admin_jwt_secret: ${{ secrets.STRAPI_ADMIN_JWT_SECRET }}
   TF_VAR_github_token: ${{ secrets.TOKEN }}
   TF_INPUT: false

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -17,8 +17,6 @@ env:
   TERRAGRUNT_VERSION: 0.31.1
   TF_VAR_rds_cluster_password: ${{ secrets.RDS_CLUSTER_PASSWORD }}
   TF_VAR_asset_bucket_name: ${{ secrets.ASSET_BUCKET_NAME }}
-  TF_VAR_strapi_aws_access_key_id: ${{ secrets.STRAPI_AWS_ACCESS_KEY_ID }}
-  TF_VAR_strapi_aws_secret_access_key: ${{ secrets.STRAPI_AWS_SECRET_ACCESS_KEY }}
   TF_VAR_strapi_admin_jwt_secret: ${{ secrets.STRAPI_ADMIN_JWT_SECRET }}
   TF_VAR_github_token: ${{ secrets.TOKEN }}
   TF_INPUT: false

--- a/components/website-cms/ecs.tf
+++ b/components/website-cms/ecs.tf
@@ -7,17 +7,17 @@ data "template_file" "cms_app" {
   template = file("./task-definitions/cms_app.json.tpl")
 
   vars = {
-    image                     = aws_ecr_repository.image-repository.repository_url
-    fargate_cpu               = var.fargate_cpu
-    fargate_memory            = var.fargate_memory
-    aws_region                = "ca-central-1"
-    awslogs-group             = aws_cloudwatch_log_group.cds-website-cms.name
-    db_host                   = aws_db_instance.website-cms-database.address
-    db_user                   = "postgres"
-    db_password_arn           = aws_ssm_parameter.db_password.arn
-    bucket_name               = var.asset_bucket_name
-    github_token_arn          = aws_ssm_parameter.github_token.arn
-    admin_jwt_secret_arn      = aws_ssm_parameter.admin_jwt_secret.arn
+    image                = aws_ecr_repository.image-repository.repository_url
+    fargate_cpu          = var.fargate_cpu
+    fargate_memory       = var.fargate_memory
+    aws_region           = "ca-central-1"
+    awslogs-group        = aws_cloudwatch_log_group.cds-website-cms.name
+    db_host              = aws_db_instance.website-cms-database.address
+    db_user              = "postgres"
+    db_password_arn      = aws_ssm_parameter.db_password.arn
+    bucket_name          = var.asset_bucket_name
+    github_token_arn     = aws_ssm_parameter.github_token.arn
+    admin_jwt_secret_arn = aws_ssm_parameter.admin_jwt_secret.arn
   }
 }
 

--- a/components/website-cms/ecs.tf
+++ b/components/website-cms/ecs.tf
@@ -16,8 +16,6 @@ data "template_file" "cms_app" {
     db_user                   = "postgres"
     db_password_arn           = aws_ssm_parameter.db_password.arn
     bucket_name               = var.asset_bucket_name
-    aws_access_key_id_arn     = aws_ssm_parameter.aws_access_key_id.arn
-    aws_secret_access_key_arn = aws_ssm_parameter.aws_secret_access_key.arn
     github_token_arn          = aws_ssm_parameter.github_token.arn
     admin_jwt_secret_arn      = aws_ssm_parameter.admin_jwt_secret.arn
   }

--- a/components/website-cms/iam.tf
+++ b/components/website-cms/iam.tf
@@ -54,8 +54,6 @@ data "aws_iam_policy_document" "ecs-task-execution" {
     resources = [
       aws_ssm_parameter.db_password.arn,
       aws_ssm_parameter.github_token.arn,
-      aws_ssm_parameter.aws_access_key_id.arn,
-      aws_ssm_parameter.aws_secret_access_key.arn,
       aws_ssm_parameter.admin_jwt_secret.arn,
     ]
   }

--- a/components/website-cms/ssm.tf
+++ b/components/website-cms/ssm.tf
@@ -10,18 +10,6 @@ resource "aws_ssm_parameter" "github_token" {
   value = var.github_token
 }
 
-resource "aws_ssm_parameter" "aws_access_key_id" {
-  name  = "/website/aws_access_key_id"
-  type  = "SecureString"
-  value = var.strapi_aws_access_key_id
-}
-
-resource "aws_ssm_parameter" "aws_secret_access_key" {
-  name  = "/website/aws_secret_access_key"
-  type  = "SecureString"
-  value = var.strapi_aws_secret_access_key
-}
-
 resource "aws_ssm_parameter" "admin_jwt_secret" {
   name  = "/website/admin_jwt_secret"
   type  = "SecureString"

--- a/components/website-cms/task-definitions/cms_app.json.tpl
+++ b/components/website-cms/task-definitions/cms_app.json.tpl
@@ -35,14 +35,6 @@
         "valueFrom" : "${github_token_arn}"
       },
       {
-        "name": "AWS_ACCESS_KEY_ID",
-        "valueFrom": "${aws_access_key_id_arn}"
-      },
-      {
-        "name": "AWS_SECRET_ACCESS_KEY",
-        "valueFrom": "${aws_secret_access_key_arn}"
-      },
-      {
         "name": "ADMIN_JWT_SECRET",
         "valueFrom": "${admin_jwt_secret_arn}"
       }

--- a/components/website-cms/variables.tf
+++ b/components/website-cms/variables.tf
@@ -29,18 +29,6 @@ variable "asset_bucket_name" {
   type = string
 }
 
-variable "strapi_aws_access_key_id" {
-  description = "AWS Access Key ID"
-  sensitive   = true
-  type        = string
-}
-
-variable "strapi_aws_secret_access_key" {
-  description = "AWS Secret Access Key"
-  sensitive   = true
-  type        = string
-}
-
 variable "strapi_admin_jwt_secret" {
   description = "Strapi Admin JWT Secret"
   sensitive   = true


### PR DESCRIPTION
# Summary
These keys are no longer required as the permissions
are now being granted by the ECS task role.

# Related
* cds-snc/cds-website-cms#21