### PR TITLE
version bump

### DIFF
--- a/components/website-cms/rds.tf
+++ b/components/website-cms/rds.tf
@@ -18,7 +18,7 @@ resource "aws_db_instance" "website-cms-database" {
   allocated_storage         = 20
   storage_type              = "gp2"
   engine                    = "postgres"
-  engine_version            = "10.18"
+  engine_version            = "10.21"
   identifier                = "strapi"
   instance_class            = "db.t3.micro"
   name                      = "strapi"


### PR DESCRIPTION
# Summary | Résumé

Current database version 10.18 support is being dropped, bumping to 10.21