### PR TITLE
fix: remove ECS task's public IP address

### DIFF
--- a/components/website-cms/ecs.tf
+++ b/components/website-cms/ecs.tf
@@ -40,8 +40,8 @@ resource "aws_ecs_service" "website-cms-ecs" {
   task_definition = aws_ecs_task_definition.cds-website-cms.arn
 
   network_configuration {
-    security_groups  = [aws_security_group.ecs_tasks.id]
-    subnets          = aws_subnet.website-cms-private.*.id
+    security_groups = [aws_security_group.ecs_tasks.id]
+    subnets         = aws_subnet.website-cms-private.*.id
   }
 
   load_balancer {

--- a/components/website-cms/ecs.tf
+++ b/components/website-cms/ecs.tf
@@ -42,7 +42,6 @@ resource "aws_ecs_service" "website-cms-ecs" {
   network_configuration {
     security_groups  = [aws_security_group.ecs_tasks.id]
     subnets          = aws_subnet.website-cms-private.*.id
-    assign_public_ip = true
   }
 
   load_balancer {

--- a/components/website-cms/rds.tf
+++ b/components/website-cms/rds.tf
@@ -18,7 +18,7 @@ resource "aws_db_instance" "website-cms-database" {
   allocated_storage           = 20
   storage_type                = "gp2"
   engine                      = "postgres"
-  engine_version              = "14.4"
+  engine_version              = "14.7"
   identifier                  = "strapi"
   instance_class              = "db.t3.micro"
   name                        = "strapi"


### PR DESCRIPTION
# Summary
Update the ECS service configuration so that tasks are no longer assigned a public IP address.

Access to the ECS task is through the ALB and not via the public IP address.

# Related
- https://github.com/cds-snc/platform-core-services/issues/471