### PR TITLE
fix: add missing strapi A record

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,9 +6,9 @@
     "aws-cli": "latest",
 
     "terraform": {
-      "version": "1.0.3",
+      "version": "1.6.1",
       "tflint": "none",
-      "terragrunt": "0.31.1"
+      "terragrunt": "0.52.2"
     }
   },
 

--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -15,8 +15,8 @@ defaults:
 
 env:
   AWS_REGION: ca-central-1
-  TERRAFORM_VERSION: 1.0.3
-  TERRAGRUNT_VERSION: 0.31.1
+  TERRAFORM_VERSION: 1.6.1
+  TERRAGRUNT_VERSION: 0.52.2
   TF_VAR_rds_cluster_password: ${{ secrets.RDS_CLUSTER_PASSWORD }}
   TF_VAR_asset_bucket_name: ${{ secrets.ASSET_BUCKET_NAME }}
   TF_VAR_strapi_admin_jwt_secret: ${{ secrets.STRAPI_ADMIN_JWT_SECRET }}

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -13,8 +13,8 @@ defaults:
 
 env:
   AWS_REGION: ca-central-1
-  TERRAFORM_VERSION: 1.0.3
-  TERRAGRUNT_VERSION: 0.31.1
+  TERRAFORM_VERSION: 1.6.1
+  TERRAGRUNT_VERSION: 0.52.2
   TF_VAR_rds_cluster_password: ${{ secrets.RDS_CLUSTER_PASSWORD }}
   TF_VAR_asset_bucket_name: ${{ secrets.ASSET_BUCKET_NAME }}
   TF_VAR_strapi_admin_jwt_secret: ${{ secrets.STRAPI_ADMIN_JWT_SECRET }}

--- a/components/website-cms/hosted_zone.tf
+++ b/components/website-cms/hosted_zone.tf
@@ -1,9 +1,0 @@
-resource "aws_route53_zone" "strapi" {
-  name    = var.domain_name
-  comment = "Hosted zone for ${var.domain_name}"
-
-  tags = {
-    (var.billing_tag_key) = var.billing_tag_value
-    Terraform             = true
-  }
-}

--- a/components/website-cms/route53.tf
+++ b/components/website-cms/route53.tf
@@ -14,8 +14,8 @@ resource "aws_route53_record" "strapi_A" {
   type    = "A"
 
   alias {
-    name                   = aws_lb.cms-load-balancer.dns_name
-    zone_id                = aws_lb.cms-load-balancer.zone_id
+    name                   = aws_alb.cms-load-balancer.dns_name
+    zone_id                = aws_alb.cms-load-balancer.zone_id
     evaluate_target_health = false
   }
 }

--- a/components/website-cms/route53.tf
+++ b/components/website-cms/route53.tf
@@ -1,0 +1,21 @@
+resource "aws_route53_zone" "strapi" {
+  name    = var.domain_name
+  comment = "Hosted zone for ${var.domain_name}"
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
+}
+
+resource "aws_route53_record" "strapi_A" {
+  zone_id = aws_route53_zone.strapi.zone_id
+  name    = var.domain_name
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.cms-load-balancer.dns_name
+    zone_id                = aws_lb.cms-load-balancer.zone_id
+    evaluate_target_health = false
+  }
+}

--- a/components/website-cms/route53.tf
+++ b/components/website-cms/route53.tf
@@ -19,3 +19,8 @@ resource "aws_route53_record" "strapi_A" {
     evaluate_target_health = false
   }
 }
+
+import {
+  to = aws_route53_record.strapi_A
+  id = "${aws_route53_zone.strapi.zone_id}_${var.domain_name}_A"
+}


### PR DESCRIPTION
# Summary
- Add the A `alias` record to the load balancer.
- Upgrade to latest Terraform/Terragrunt so that an `import` block can be used to add the existing `A` record to the TF state.

# Related
- https://github.com/cds-snc/platform-core-services/issues/471