### PR TITLE
chore: remove A record import block

### DIFF
--- a/components/website-cms/route53.tf
+++ b/components/website-cms/route53.tf
@@ -19,8 +19,3 @@ resource "aws_route53_record" "strapi_A" {
     evaluate_target_health = false
   }
 }
-
-import {
-  to = aws_route53_record.strapi_A
-  id = "${aws_route53_zone.strapi.zone_id}_${var.domain_name}_A"
-}


### PR DESCRIPTION
# Summary
Now that the resource has been imported to the
TF state, the block can be removed.

# Related
- https://github.com/cds-snc/cds-website-terraform/pull/46
- https://github.com/cds-snc/platform-core-services/issues/471