### PR TITLE
fix: enable ECS container insights

### DIFF
--- a/components/website-cms/ecs.tf
+++ b/components/website-cms/ecs.tf
@@ -1,6 +1,10 @@
 resource "aws_ecs_cluster" "website-cms-cluster" {
   name = "website-cms-cluster"
-  #tfsec:ignore:AWS090 - no container insights
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
 }
 
 data "template_file" "cms_app" {


### PR DESCRIPTION
# Summary
Update the CMS ECS cluster to enable container insights.  This is part of the Security Hub finding cleanup.

# Related
- https://github.com/cds-snc/platform-core-services/issues/471