### PR TITLE
fix: block public access to website asset bucket

### DIFF
--- a/components/website-cms/s3.tf
+++ b/components/website-cms/s3.tf
@@ -38,3 +38,12 @@ resource "aws_s3_bucket_policy" "website-asset-bucket" {
 }
 POLICY
 }
+
+resource "aws_s3_bucket_public_access_block" "website-asset-bucket" {
+  bucket = aws_s3_bucket.website-asset-bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}


### PR DESCRIPTION
# Summary
Update the S3 asset bucket to block all public access to its objects. This will force all access to be made through the website's CloudFront URL.

# Related
- https://github.com/cds-snc/platform-core-services/issues/471