### PR TITLE
fix: enable RDS instance delete protection

### DIFF
--- a/components/website-cms/rds.tf
+++ b/components/website-cms/rds.tf
@@ -27,12 +27,13 @@ resource "aws_db_instance" "website-cms-database" {
   password                    = aws_ssm_parameter.db_password.value
   backup_retention_period     = 7
   backup_window               = "07:00-09:00"
+  copy_tags_to_snapshot       = true
   db_subnet_group_name        = aws_db_subnet_group.website-cms.name
   allow_major_version_upgrade = true
+  deletion_protection         = true
 
   # Ignore TFSEC rule as we are using managed KMS
   storage_encrypted = true #tfsec:ignore:AWS051
-
 
   vpc_security_group_ids = [
     aws_security_group.website-cms-database.id


### PR DESCRIPTION
# Summary
Update the Strapi RDS instance to prevent accidental deletion. Also updates the configuration so that instance tags are copied to snapshots.

# Related
- https://github.com/cds-snc/platform-core-services/issues/471