### PR TITLE
chore: upgrade ALB to recommend SSL policy

### DIFF
--- a/components/website-cms/alb.tf
+++ b/components/website-cms/alb.tf
@@ -38,7 +38,7 @@ resource "aws_alb_listener" "front_end" {
   load_balancer_arn = aws_alb.cms-load-balancer.id
   port              = 443
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-TLS13-1-0-2021-06"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04"
   certificate_arn   = aws_acm_certificate_validation.strapi.certificate_arn
 
   default_action {

--- a/components/website-cms/rds.tf
+++ b/components/website-cms/rds.tf
@@ -18,7 +18,7 @@ resource "aws_db_instance" "website-cms-database" {
   allocated_storage           = 20
   storage_type                = "gp2"
   engine                      = "postgres"
-  engine_version              = "14.10"
+  engine_version              = "14.12"
   identifier                  = "strapi"
   instance_class              = "db.t3.micro"
   name                        = "strapi"


### PR DESCRIPTION
# Summary
Update to the latest recommend ALB SSL policy which is FIPS 140-3 compliant.